### PR TITLE
Missing include: agorithm

### DIFF
--- a/CMakePasm/eolconvert/eolconvert.cc
+++ b/CMakePasm/eolconvert/eolconvert.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <filesystem>
 #include <set>


### PR DESCRIPTION
This missing include causes compilation error

    error: ‘all_of’ is not a member of ‘std’